### PR TITLE
Deprecate old CMake versions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.2...3.27)
+cmake_minimum_required(VERSION 3.10)
 project(cmake_git_version_tracking
     LANGUAGES C)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.10..4.1)
 project(cmake_git_version_tracking
     LANGUAGES C)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10..4.1)
+cmake_minimum_required(VERSION 3.10...4.1)
 project(cmake_git_version_tracking
     LANGUAGES C)
 

--- a/tests/hello-world/CMakeLists.txt
+++ b/tests/hello-world/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.11)
 project(hello-world)
 
 set(VERSION_TRACKING_MODULE_PATH "" CACHE STRING "The location of the cmake-git-version-tracking repository")


### PR DESCRIPTION
Tested with 4.1
Setting minimum to 3.10 as Changed in version 3.31: Compatibility with versions of CMake older than 3.10 is deprecated